### PR TITLE
아이계정 아이디 중복 체크 기능 추가

### DIFF
--- a/src/main/java/com/project/growfit/domain/auth/controller/AuthChildController.java
+++ b/src/main/java/com/project/growfit/domain/auth/controller/AuthChildController.java
@@ -1,8 +1,9 @@
 package com.project.growfit.domain.auth.controller;
 
+import com.project.growfit.domain.User.dto.response.ChildInfoResponseDto;
+import com.project.growfit.domain.auth.dto.request.AuthChildRegisterRequestDto;
 import com.project.growfit.domain.auth.dto.request.AuthChildRequestDto;
 import com.project.growfit.domain.auth.dto.request.FindChildPasswordRequestDto;
-import com.project.growfit.domain.User.dto.response.ChildInfoResponseDto;
 import com.project.growfit.domain.auth.dto.response.ChildResponseDto;
 import com.project.growfit.domain.auth.service.AuthChildService;
 import com.project.growfit.global.response.ResultCode;
@@ -36,7 +37,7 @@ public class AuthChildController {
     @Operation(summary = "아이 회원가입 시 아이디 & 비밀번호 & 닉네임 등록")
     @PostMapping("/register/{child_id}/credentials")
     public ResultResponse<ChildInfoResponseDto> registerChildCredentials(@PathVariable Long child_id,
-                                                                         @Valid @RequestBody AuthChildRequestDto request) {
+                                                                         @Valid @RequestBody AuthChildRegisterRequestDto request) {
         ChildInfoResponseDto dto = authChildService.registerChildCredentials(child_id, request);
 
         return ResultResponse.of(ResultCode.INFO_REGISTRATION_SUCCESS, dto);
@@ -56,6 +57,12 @@ public class AuthChildController {
         ChildResponseDto dto = authChildService.logout(response);
 
         return ResultResponse.of(ResultCode.LOGOUT_SUCCESS, dto);
+    }
+
+    @GetMapping("/check-id")
+    public ResultResponse<String> checkDuplicateLoginId(@RequestParam String loginId) {
+        String result = authChildService.isLoginIdDuplicate(loginId);
+        return ResultResponse.of(ResultCode.DUPLICATE_SUCCESS, result);
     }
 
     @Operation(summary = "아이 인증코드로 ID 찾기")

--- a/src/main/java/com/project/growfit/domain/auth/dto/request/AuthChildRegisterRequestDto.java
+++ b/src/main/java/com/project/growfit/domain/auth/dto/request/AuthChildRegisterRequestDto.java
@@ -3,8 +3,7 @@ package com.project.growfit.domain.auth.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
-public record AuthChildRequestDto(
-
+public record AuthChildRegisterRequestDto(
         @Schema(description = "아이 로그인 ID", example = "child123")
         @NotBlank(message = "아이디를 입력해주세요.")
         @Size(min = 4, max = 20, message = "아이디는 4자 이상 20자 이하로 입력해주세요.")

--- a/src/main/java/com/project/growfit/domain/auth/dto/request/AuthChildRequestDto.java
+++ b/src/main/java/com/project/growfit/domain/auth/dto/request/AuthChildRequestDto.java
@@ -1,0 +1,21 @@
+package com.project.growfit.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record AuthChildRequestDto(
+        @Schema(description = "아이 로그인 ID", example = "child123")
+        @NotBlank(message = "아이디를 입력해주세요.")
+        @Size(min = 4, max = 20, message = "아이디는 4자 이상 20자 이하로 입력해주세요.")
+        String childId,
+
+        @Schema(description = "아이 로그인 비밀번호", example = "password123")
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*\\d)[a-z\\d@$!%*?&]{8,}$",
+                message = "비밀번호는 소문자와 숫자를 포함하여 8자 이상이어야 합니다.")
+        String childPassword
+) {
+}

--- a/src/main/java/com/project/growfit/domain/auth/service/AuthChildService.java
+++ b/src/main/java/com/project/growfit/domain/auth/service/AuthChildService.java
@@ -1,5 +1,6 @@
 package com.project.growfit.domain.auth.service;
 
+import com.project.growfit.domain.auth.dto.request.AuthChildRegisterRequestDto;
 import com.project.growfit.domain.auth.dto.request.AuthChildRequestDto;
 import com.project.growfit.domain.auth.dto.request.FindChildPasswordRequestDto;
 import com.project.growfit.domain.User.dto.response.ChildInfoResponseDto;
@@ -8,9 +9,10 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthChildService {
     ChildResponseDto findByCode(String code);
-    ChildInfoResponseDto registerChildCredentials(Long child_id, AuthChildRequestDto request);
+    ChildInfoResponseDto registerChildCredentials(Long child_id, AuthChildRegisterRequestDto request);
     ChildResponseDto login(AuthChildRequestDto request, HttpServletResponse response);
     ChildResponseDto logout(HttpServletResponse response);
     ChildResponseDto findChildID(String code);
     ChildInfoResponseDto findChildPassword(FindChildPasswordRequestDto request);
+    String isLoginIdDuplicate(String loginId);
 }

--- a/src/main/java/com/project/growfit/domain/auth/service/impl/AuthChildServiceImpl.java
+++ b/src/main/java/com/project/growfit/domain/auth/service/impl/AuthChildServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.growfit.domain.auth.service.impl;
 
+import com.project.growfit.domain.auth.dto.request.AuthChildRegisterRequestDto;
 import com.project.growfit.domain.auth.dto.request.AuthChildRequestDto;
 import com.project.growfit.domain.auth.dto.request.FindChildPasswordRequestDto;
 import com.project.growfit.domain.User.dto.response.ChildInfoResponseDto;
@@ -46,11 +47,9 @@ public class AuthChildServiceImpl implements AuthChildService {
 
     @Override
     @Transactional
-    public ChildInfoResponseDto registerChildCredentials(Long child_id, AuthChildRequestDto request) {
+    public ChildInfoResponseDto registerChildCredentials(Long child_id, AuthChildRegisterRequestDto request) {
         log.debug("[registerChildCredentials] 아이 계정 정보 등록 요청: child_id={}, child_login_id={}", child_id, request.childId());
-        if (childRepository.existsByLoginId(request.childId())) {
-            throw new BusinessException(ErrorCode.CHILD_ALREADY_EXISTS);
-        }
+        if (childRepository.existsByLoginId(request.childId())) throw new BusinessException(ErrorCode.DUPLICATED_ID);
         validatePasswordStrength(request.childPassword());
         Child child = getChild(child_id);
 
@@ -132,6 +131,13 @@ public class AuthChildServiceImpl implements AuthChildService {
         log.info("[findChildPassword] 비밀번호 변경 완료: user_id={}", request.user_id());
 
         return ChildInfoResponseDto.toDto(child);
+    }
+
+    @Override
+    @Transactional
+    public String isLoginIdDuplicate(String loginId) {
+        boolean isLoginDuplicate = childRepository.existsByLoginId(loginId);
+        return isLoginDuplicate ? "이미 사용 중인 아이디입니다." : "사용 가능한 아이디입니다.";
     }
 
     private Child getChild(Long child_id) {

--- a/src/main/java/com/project/growfit/global/response/ResultCode.java
+++ b/src/main/java/com/project/growfit/global/response/ResultCode.java
@@ -20,6 +20,7 @@ public enum ResultCode {
 
     INFO_SUCCESS(HttpStatus.OK,  "성공적으로 정보가 조회되었습니다."),
     UPDATE_SUCCESS(HttpStatus.OK,  "성공적으로 정보가 수정되었습니다."),
+    DUPLICATE_SUCCESS(HttpStatus.OK, "성공적으로 중복여부를 조회하였습니다."),
 
     //Diet
     STICKER_MARK_SUCCESS(HttpStatus.OK, "스티커가 성공적으로 등록되었습니다."),

--- a/src/test/java/com/project/growfit/domain/auth/service/impl/AuthChildServiceImplTest.java
+++ b/src/test/java/com/project/growfit/domain/auth/service/impl/AuthChildServiceImplTest.java
@@ -1,12 +1,13 @@
 package com.project.growfit.domain.auth.service.impl;
 
-import com.project.growfit.domain.auth.dto.request.AuthChildRequestDto;
-import com.project.growfit.domain.auth.dto.request.FindChildPasswordRequestDto;
 import com.project.growfit.domain.User.dto.response.ChildInfoResponseDto;
-import com.project.growfit.domain.auth.dto.response.ChildResponseDto;
 import com.project.growfit.domain.User.entity.Child;
 import com.project.growfit.domain.User.entity.ROLE;
 import com.project.growfit.domain.User.repository.ChildRepository;
+import com.project.growfit.domain.auth.dto.request.AuthChildRegisterRequestDto;
+import com.project.growfit.domain.auth.dto.request.AuthChildRequestDto;
+import com.project.growfit.domain.auth.dto.request.FindChildPasswordRequestDto;
+import com.project.growfit.domain.auth.dto.response.ChildResponseDto;
 import com.project.growfit.global.auth.cookie.CookieService;
 import com.project.growfit.global.auth.jwt.JwtProvider;
 import com.project.growfit.global.auth.service.AuthenticatedUserProvider;
@@ -109,7 +110,7 @@ class AuthChildServiceImplTest {
     void 아이_계졍을_성공적으로_등록한다() {
         // Given
         Long childId = 1L;
-        AuthChildRequestDto request = new AuthChildRequestDto(loginId, password, nickname);
+        AuthChildRegisterRequestDto request = new AuthChildRegisterRequestDto(loginId, password, nickname);
         when(childRepository.findById(childId)).thenReturn(Optional.of(mockChild));
         when(passwordEncoder.encode(request.childPassword())).thenReturn("encodedPassword");
 
@@ -126,7 +127,7 @@ class AuthChildServiceImplTest {
     void 아이_정보가_없는_경우_아이_등록에_실패한다() {
         // Given
         Long childId = 999L;
-        AuthChildRequestDto request = new AuthChildRequestDto(loginId, password, nickname);
+        AuthChildRegisterRequestDto  request = new  AuthChildRegisterRequestDto (loginId, password,  nickname);
         when(childRepository.findById(childId)).thenReturn(Optional.empty());
 
         // When & Then
@@ -175,7 +176,7 @@ class AuthChildServiceImplTest {
     @DisplayName("[login 성공 테스트] 아이 로그인 성공")
     void 아이_로그인에_성공한다() {
         // Given
-        AuthChildRequestDto request = new AuthChildRequestDto(loginId, password, nickname);
+        AuthChildRequestDto request = new AuthChildRequestDto(loginId, password);
         Child mockChild = new Child(loginId, nickname, password, ROLE.ROLE_CHILD);
 
         Authentication mockAuthentication = mock(Authentication.class);


### PR DESCRIPTION
## 📌 연관된 이슈
> 이슈 번호를 작성해주세요. ex) - #이슈번호 
- #58 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 아이계정 생성 시 , 아이디 중복처리하는 기능을 추가하였습니다.
- 아이계정 로그인 시, 별명을 추가로 입력해야하는 불편함을 해결하기 위해 회원가입 DTO와 로그인 DTO를 분리하였습니다.


## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요